### PR TITLE
Fix Makefile error

### DIFF
--- a/llvm/Makefile
+++ b/llvm/Makefile
@@ -5,7 +5,7 @@ all : check_cycles test
 test : check_cycles
 
 check_cycles : check_cycles.cpp
-	$(CXX) -O3 -Wall -std=c++14 $(shell llvm-config --cxxflags --ldflags --libs --system-libs) $< -o $@
+	$(CXX) -O3 -Wall -std=c++14 $< $(shell llvm-config --cxxflags --ldflags --libs --system-libs) -o $@
 
 TESTS=$(patsubst tests/%.c,%,$(wildcard tests/*.c))
 


### PR DESCRIPTION
Fix Makefile error leading to llvm-config output ignored and
ld failure.