### PR TITLE
WIP: Split blocks

### DIFF
--- a/llvm/Makefile
+++ b/llvm/Makefile
@@ -1,10 +1,13 @@
 .PRECIOUS : tests/%.ll
 
-all : check_cycles test
+all : split_blocks check_cycles test
 
 test : check_cycles
 
 check_cycles : check_cycles.cpp
+	$(CXX) -O3 -Wall -std=c++14 $< $(shell llvm-config --cxxflags --ldflags --libs --system-libs) -o $@
+
+split_blocks : split_blocks.cpp
 	$(CXX) -O3 -Wall -std=c++14 $< $(shell llvm-config --cxxflags --ldflags --libs --system-libs) -o $@
 
 TESTS=$(patsubst tests/%.c,%,$(wildcard tests/*.c))

--- a/llvm/Makefile
+++ b/llvm/Makefile
@@ -5,7 +5,7 @@ all : check_cycles test
 test : check_cycles
 
 check_cycles : check_cycles.cpp
-	$(CXX) -O3 -Wall -std=c++14 $(shell llvm-config --cxxflags --ldflags --libs --system-libs) $< -o $@
+	$(CXX) -O3 -Wall -std=c++14 $< $(shell llvm-config --cxxflags --ldflags --libs --system-libs) -o $@
 
 TESTS=$(patsubst tests/%.c,%,$(wildcard tests/*.c))
 

--- a/llvm/split_blocks.cpp
+++ b/llvm/split_blocks.cpp
@@ -1,0 +1,78 @@
+#include "llvm/IR/Module.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/BasicBlock.h"
+
+#include <iostream>
+#include <vector>
+#include <map>
+
+using namespace llvm;
+using namespace std;
+
+typedef string TracePoint;
+
+
+class SimpleVisitor : public InstVisitor<SimpleVisitor> {
+
+public:
+    void visitBasicBlock(BasicBlock &bb) {
+        for (auto i = bb.begin(); i != bb.end();) {
+            Instruction *Inst = &*i++;
+            bb.printAsOperand(errs(), false); 
+            cout << " " << Inst->getOpcodeName() << endl;
+        }
+    }
+};
+
+
+class SplittingVisitor : public InstVisitor<SplittingVisitor> {
+
+public:
+    void visitBasicBlock(BasicBlock &bb) {
+        for (auto i = bb.begin(); i != bb.end();) {
+            Instruction *Inst = &*i++;
+            bb.splitBasicBlock(i);
+            break;
+            bb.printAsOperand(errs(), false); 
+            cout << " " << Inst->getOpcodeName() << endl;
+        }
+    }
+};
+
+
+int main_(Module& M) {
+    auto SV = SimpleVisitor();
+    auto SpV = SplittingVisitor();
+    SV.visit(M);
+    cout << endl;
+    SpV.visit(M);
+    cout << endl;
+    SV.visit(M);
+    return 0;
+}
+
+
+int main(int argc, char **argv) {
+    // if (argc != 4) {
+    //     cerr << "Usage: " << argv[0] << " <IR file> <Start tracepoint> <Final tracepoint>\n";
+    //     return 1;
+    // }
+
+    // Parse the input LLVM IR file into a module.
+    SMDiagnostic Err;
+    LLVMContext Context;
+    unique_ptr <Module> Mod(parseIRFile(argv[1], Err, Context));
+    if (!Mod) {
+        Err.print(argv[0], errs());
+        return 1;
+    }
+    main_(*Mod);
+
+    // dump module
+    // const char *Path = "simple.s"; 
+    // int ans = LLVMWriteBitcodeToFile(Mod, Path);   
+    return 0;
+}


### PR DESCRIPTION
You can use *make* to compile split_blocks and use it like that
```
./split_blocks test_simple.ll
```
Example output:
```
%0 alloca
%0 store
%0 ret


%0 alloca
%0 br
%2 store
%2 ret
```
Code structure:
There are two visitors:
1. just traverses through blocks and instructions, printing block label and instruction name
2. splits each block *after* first instruction